### PR TITLE
[2024/06/20] feat/create-menu >> 카페 메뉴 등록 기능 구현

### DIFF
--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/MenuController.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/MenuController.java
@@ -5,12 +5,10 @@ import com.sparta.coffeedeliveryproject.dto.MenuResponseDto;
 import com.sparta.coffeedeliveryproject.service.MenuService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-@RestController("/admin/cafes")
+@RestController
+@RequestMapping("/admin/cafes")
 public class MenuController {
 
     private final MenuService menuService;

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/MenuController.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/MenuController.java
@@ -1,4 +1,31 @@
 package com.sparta.coffeedeliveryproject.controller;
 
+import com.sparta.coffeedeliveryproject.dto.MenuRequestDto;
+import com.sparta.coffeedeliveryproject.dto.MenuResponseDto;
+import com.sparta.coffeedeliveryproject.service.MenuService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("/admin/cafes")
 public class MenuController {
+
+    private final MenuService menuService;
+
+    public  MenuController(MenuService menuService) {
+        this.menuService = menuService;
+    }
+
+    @PostMapping("/{cafeId}/menus")
+    public ResponseEntity<MenuResponseDto> createMenu(@PathVariable(value = "cafeId") Long cafeId,
+                                                      @RequestBody MenuRequestDto requestDto) {
+
+        MenuResponseDto responseDto = menuService.createMenu(cafeId, requestDto);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/MenuRequestDto.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/MenuRequestDto.java
@@ -1,0 +1,12 @@
+package com.sparta.coffeedeliveryproject.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MenuRequestDto {
+
+    private String menuName;
+
+    private Long menuPrice;
+
+}

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/MenuResponseDto.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/MenuResponseDto.java
@@ -1,0 +1,24 @@
+package com.sparta.coffeedeliveryproject.dto;
+
+import com.sparta.coffeedeliveryproject.entity.Menu;
+import lombok.Getter;
+
+@Getter
+public class MenuResponseDto {
+
+    private Long menuId;
+
+    private String menuName;
+
+    private Long menuPrice;
+
+    private Long cafeId;
+
+    public MenuResponseDto(Menu menu) {
+        this.menuId = menu.getMenuId();
+        this.menuName = menu.getMenuName();
+        this.menuPrice = menu.getMenuPrice();
+        this.cafeId = menu.getCafeId();
+    }
+
+}

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/Menu.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/Menu.java
@@ -20,6 +20,7 @@ public class Menu {
     @Column(name = "menu_price", nullable = false)
     private Long menuPrice;
 
+    // 밑에 주석 3개는 아직 Cafe Entity가 구현되지 않아 맵핑 부분에 오류가 있어서 주석처리했습니다.
 //    @JoinColumn(name = "cafe_id", nullable = false)
 //    private Cafe cafe;
 

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/Menu.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/Menu.java
@@ -1,4 +1,36 @@
 package com.sparta.coffeedeliveryproject.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "menu")
 public class Menu {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long menuId;
+
+    @Column(name = "menu_name", nullable = false)
+    private String menuName;
+
+    @Column(name = "menu_price", nullable = false)
+    private Long menuPrice;
+
+//    @JoinColumn(name = "cafe_id", nullable = false)
+//    private Cafe cafe;
+
+    @Column(name = "cafe_id", nullable = false)
+    private Long cafeId;
+
+    public Menu(String menuName, Long menuPrice, Long cafeId) {
+        this.menuName = menuName;
+        this.menuPrice = menuPrice;
+        this.cafeId = cafeId;
+//        this.cafe = cafe;
+    }
+
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/repository/MenuRepository.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/repository/MenuRepository.java
@@ -1,4 +1,7 @@
 package com.sparta.coffeedeliveryproject.repository;
 
-public interface MenuRepository {
+import com.sparta.coffeedeliveryproject.entity.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/MenuService.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/MenuService.java
@@ -1,4 +1,28 @@
 package com.sparta.coffeedeliveryproject.service;
 
+import com.sparta.coffeedeliveryproject.dto.MenuRequestDto;
+import com.sparta.coffeedeliveryproject.dto.MenuResponseDto;
+import com.sparta.coffeedeliveryproject.entity.Menu;
+import com.sparta.coffeedeliveryproject.repository.MenuRepository;
+import org.springframework.stereotype.Service;
+
+@Service
 public class MenuService {
+
+    private final MenuRepository menuRepository;
+
+    public MenuService(MenuRepository menuRepository) {
+        this.menuRepository = menuRepository;
+    }
+
+    public MenuResponseDto createMenu(Long cafeId, MenuRequestDto requestDto) {
+
+        String menuName = requestDto.getMenuName();
+        Long menuPrice = requestDto.getMenuPrice();
+        Menu menu = new Menu(menuName, menuPrice, cafeId);
+
+        Menu saveMenu = menuRepository.save(menu);
+
+        return new MenuResponseDto(saveMenu);
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#1

## 📝 작업 내용

- 카페 메뉴 등록을 위한 Menu Entity 구현
- MenuController에 메뉴 등록 API 구현
- MenuService에 메뉴 등록 비즈니스 로직 구현
- 비즈니스 로직에 필요한 MenuRepository 구현

### 📸 스크린샷
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/48900537/02640222-e914-4964-b443-c992422a35b2)

## 💬 리뷰 요구사항

Cafe Entity 미구현으로 Entity 맵핑이 안되어 있습니다.
그래서 Menu Entity에 맵핑을 주석으로 작성해 두었고, 임시로 cafeId 필드를 작성해서 사용했습니다.

추 후에 Cafe Entity 구현 되면, Entity 맵핑을 진행하고 Issue를 close 하겠습니다.