### PR TITLE
[2024/06/20] feat/delete-menu >> 카페 메뉴 삭제 기능 구현

### DIFF
--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/MenuController.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/MenuController.java
@@ -2,6 +2,7 @@ package com.sparta.coffeedeliveryproject.controller;
 
 import com.sparta.coffeedeliveryproject.dto.MenuRequestDto;
 import com.sparta.coffeedeliveryproject.dto.MenuResponseDto;
+import com.sparta.coffeedeliveryproject.dto.MessageResponseDto;
 import com.sparta.coffeedeliveryproject.service.MenuService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +23,14 @@ public class MenuController {
                                                       @RequestBody MenuRequestDto requestDto) {
 
         MenuResponseDto responseDto = menuService.createMenu(cafeId, requestDto);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+
+    @DeleteMapping("/menus/{menuId}")
+    public ResponseEntity<MessageResponseDto> deleteMenu(@PathVariable(value = "menuId") Long menuId) {
+
+       MessageResponseDto responseDto = menuService.deleteMenu(menuId);
 
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/MessageResponseDto.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/MessageResponseDto.java
@@ -1,11 +1,14 @@
 package com.sparta.coffeedeliveryproject.dto;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+
 @Getter
-@RequiredArgsConstructor
 public class MessageResponseDto {
 
     private String message;
+
+    public MessageResponseDto(String message) {
+        this.message = message;
+    }
 
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/MenuService.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/MenuService.java
@@ -2,6 +2,7 @@ package com.sparta.coffeedeliveryproject.service;
 
 import com.sparta.coffeedeliveryproject.dto.MenuRequestDto;
 import com.sparta.coffeedeliveryproject.dto.MenuResponseDto;
+import com.sparta.coffeedeliveryproject.dto.MessageResponseDto;
 import com.sparta.coffeedeliveryproject.entity.Menu;
 import com.sparta.coffeedeliveryproject.repository.MenuRepository;
 import org.springframework.stereotype.Service;
@@ -24,5 +25,16 @@ public class MenuService {
         Menu saveMenu = menuRepository.save(menu);
 
         return new MenuResponseDto(saveMenu);
+    }
+
+    public MessageResponseDto deleteMenu(Long menuId) {
+
+        Menu menu = menuRepository.findById(menuId).orElseThrow(
+                () -> new IllegalArgumentException("해당 메뉴를 찾을 수 없습니다.")
+        );
+
+        menuRepository.delete(menu);
+
+        return new MessageResponseDto("삭제 완료 되었습니다.");
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#13 

## 📝 작업 내용

- MenuController에 메뉴 삭제 API 구현
- MenuService에 메뉴 삭제 비즈니스 로직 구현

### 📸 스크린샷 

- menuId 4번 삭제 요청
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/48900537/0f7f5623-e357-4d56-8c81-e674b5573532)

- DB에서 menuId 4번 삭제 확인
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/48900537/85db4433-91b3-40e3-a294-a9c31de76ceb)

