### PR TITLE
[2024/06/21] feat/delete-order >> 주문 삭제 기능 구현

### DIFF
--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminOrderController.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminOrderController.java
@@ -5,10 +5,7 @@ import com.sparta.coffeedeliveryproject.service.AdminOrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/admin")
@@ -28,6 +25,13 @@ public class AdminOrderController {
     @PutMapping("/orders/cancel/{orderId}")
     public ResponseEntity<MessageResponseDto> cancelOrder(@PathVariable Long orderId) {
         MessageResponseDto responseDto = adminOrderService.cancelOrder(orderId);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+
+    // 주문 삭제
+    @DeleteMapping("/orders/{orderId}")
+    public ResponseEntity<MessageResponseDto> deleteOrder(@PathVariable Long orderId) {
+        MessageResponseDto responseDto = adminOrderService.deleteOrder(orderId);
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminOrderService.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminOrderService.java
@@ -30,6 +30,13 @@ public class AdminOrderService {
         return new MessageResponseDto("주문이 취소되었습니다.");
     }
 
+    //주문 삭제
+    public MessageResponseDto deleteOrder(Long orderId) {
+        Order order = findOrderById(orderId);
+        orderRepository.delete(order);
+        return new MessageResponseDto("주문이 삭제되었습니다.");
+    }
+
     //id로 주문 찾기
     private Order findOrderById(Long orderId) {
         return orderRepository.findById(orderId).orElseThrow(() ->


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#27 

## 📝 작업 내용
- AdminiOrderController, Service 에 주문 삭제 기능 API, 비지니스 로직 구현
- 어드민만 가능하다는 조건은 아직 구현 X


### 📸 스크린샷
- 삭제 전 DB

![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/166794538/5e4f9706-56c1-4681-b17d-ac7cb92b4c77)

- 주문 삭제 기능
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/166794538/1fe6c3a7-aeb6-4459-90e6-8d5a77272150)


- 삭제 후 DB 반영

![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/166794538/c9dff227-eebd-4f4c-b6c3-f53acac0a459)


