### PR TITLE
[2024/06/21] feat/edit-user >> 유저 정보 수정 기능

### DIFF
--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminUserController.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminUserController.java
@@ -1,11 +1,15 @@
 package com.sparta.coffeedeliveryproject.controller;
 
+import com.sparta.coffeedeliveryproject.dto.UserEditRequestDto;
 import com.sparta.coffeedeliveryproject.dto.UserResponseDto;
+import com.sparta.coffeedeliveryproject.exceptions.PasswordMismatchException;
+import com.sparta.coffeedeliveryproject.exceptions.RecentlyUsedPasswordException;
+import com.sparta.coffeedeliveryproject.exceptions.UserNotFoundException;
 import com.sparta.coffeedeliveryproject.service.AdminUserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,6 +24,27 @@ public class AdminUserController {
     @GetMapping("/users")
     public List<UserResponseDto> gellAllUsers() {
         return adminUserService.getAllUsers();
+    }
+
+    // 특정 유저 수정
+    @PutMapping("/users/{userId}")
+    public UserResponseDto editUser(@PathVariable Long userId, @RequestBody UserEditRequestDto userEditRequestDto) {
+        return adminUserService.editUser(userId, userEditRequestDto);
+    }
+
+    @ExceptionHandler // 에러 핸들링
+    private ResponseEntity<String> handleException(RecentlyUsedPasswordException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler // 에러 핸들링
+    private ResponseEntity<String> handleException(UserNotFoundException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler // 에러 핸들링
+    private ResponseEntity<String> handleException(PasswordMismatchException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/UserEditRequestDto.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/UserEditRequestDto.java
@@ -1,10 +1,15 @@
 package com.sparta.coffeedeliveryproject.dto;
 
+import lombok.Getter;
+
+@Getter
 public class UserEditRequestDto {
 
     private String newUserName;
 
     private String newNickName;
+
+    private String password;
 
     private String newPassword;
 

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/UserEditRequestDto.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/UserEditRequestDto.java
@@ -1,0 +1,11 @@
+package com.sparta.coffeedeliveryproject.dto;
+
+public class UserEditRequestDto {
+
+    private String newUserName;
+
+    private String newNickName;
+
+    private String newPassword;
+
+}

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/User.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/User.java
@@ -31,7 +31,7 @@ public class User {
 
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
-    private UserStatusEnum userStatus;
+    private UserStatusEnum userStatus = UserStatusEnum.ACTIVE;
 
     @ManyToMany
     @JoinTable(
@@ -49,16 +49,13 @@ public class User {
     @Column(name = "past_password")
     private Set<String> pastPasswords = new HashSet<>();
 
-    @Column(nullable = false)
+    @Column
     private String refreshToken;
 
-    public User(String userName, String password, String nickName, Set<UserRole> userRoles, UserStatusEnum userStatusEnum, String refreshToken) {
+    public User(String userName, String password, String nickName) {
         this.userName = userName;
         this.password = password;
         this.nickName = nickName;
-        this.userRoles = userRoles;
-        this.userStatus = userStatusEnum;
-        this.refreshToken = refreshToken;
     }
 
     public void addUserRoles(UserRole userRole) {
@@ -75,6 +72,14 @@ public class User {
 
     public void editUserPassword(String password) {
         this.password = password;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void setUserRoles(Set<UserRole> userRoles) {
+        this.userRoles = userRoles;
     }
 
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/User.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/User.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -46,7 +47,7 @@ public class User {
     @CollectionTable(name = "past_passwords", joinColumns = @JoinColumn(name = "user_id"))
     // pastPasswords 테이블의 컬렉션 값이 past_password로 저장
     @Column(name = "past_password")
-    private List<String> pastPasswords = new LinkedList<>();
+    private Set<String> pastPasswords = new HashSet<>();
 
     @Column(nullable = false)
     private String refreshToken;
@@ -62,6 +63,18 @@ public class User {
 
     public void addUserRoles(UserRole userRole) {
         this.userRoles.add(userRole);
+    }
+
+    public void editUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public void editUserNickName(String nickName) {
+        this.nickName = nickName;
+    }
+
+    public void editUserPassword(String password) {
+        this.password = password;
     }
 
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/exceptions/PasswordMismatchException.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/exceptions/PasswordMismatchException.java
@@ -1,0 +1,11 @@
+package com.sparta.coffeedeliveryproject.exceptions;
+
+public class PasswordMismatchException extends RuntimeException{
+
+    public PasswordMismatchException(String message) {
+
+        super(message);
+
+    }
+
+}

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/exceptions/RecentlyUsedPasswordException.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/exceptions/RecentlyUsedPasswordException.java
@@ -1,0 +1,12 @@
+package com.sparta.coffeedeliveryproject.exceptions;
+
+public class RecentlyUsedPasswordException extends RuntimeException{
+
+    public RecentlyUsedPasswordException(String message) {
+
+        super(message);
+
+    }
+
+}
+

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/exceptions/UserNotFoundException.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/exceptions/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package com.sparta.coffeedeliveryproject.exceptions;
+
+public class UserNotFoundException extends RuntimeException{
+
+    public UserNotFoundException(String message) {
+
+        super(message);
+
+    }
+
+}

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/initalizer/DataInitializer.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/initalizer/DataInitializer.java
@@ -50,9 +50,13 @@ public class DataInitializer implements CommandLineRunner {
             user3Roles.add(userRole); // 관리자는 USER 역할과 ADMIN 역할을 모두 가짐
             user3Roles.add(adminRole);
 
-            User user1 = new User("user1", "password123", "NickName1", user1Roles, UserStatusEnum.ACTIVE, "refresh_token_1");
-            User user2 = new User("user2", "password12223", "NickName2", user2Roles, UserStatusEnum.ACTIVE, "refresh_token_1");
-            User user3 = new User("user3", "password123", "NickName3", user3Roles, UserStatusEnum.ACTIVE, "refresh_token_1");
+            User user1 = new User("user1", "password123", "NickName1");
+            User user2 = new User("user2", "password12223", "NickName2");
+            User user3 = new User("user3", "password123", "NickName3");
+
+            user1.setUserRoles(user1Roles);
+            user2.setUserRoles(user2Roles);
+            user3.setUserRoles(user3Roles);
 
             // 유저 role 추가되는 것이 가능한지 테스트
             user2.addUserRoles(adminRole);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#24 #23 
close #24 

![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/71262367/aab2c475-b2ea-403d-afa4-ac1d4a242cdc)
모르고 커밋을 23번에 해버렸어요..

## 📝 작업 내용
- UserEditRequetDto 생성
- 커스텀 에러 생성 + 예외 처리
- User 과거 비밀번호 저장하는 곳 List -> Set으로 변경했습니다! (중복  막기 위해!)
- 유저 정보 수정하는 로직 구현했습니다! (아직 관리자인지 아닌지 검사는 x)

### 📸 스크린샷
**유저 정보 수정 성공시**
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/71262367/7236a08d-5de0-4d34-bbfe-53ad59f21cda)

**비밀번호가 일치하지 않을 때**
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/71262367/10cb3dfa-2486-42d5-a8f2-61eb55d0487a)

**최근 4개 비밀번호로 새 비밀번호를 설정하려 할때**
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/71262367/e48ae642-02a8-4b90-9c3f-78bfd12a71ba)


