### PR TITLE
[2024/06/21] feat/get-all-cafe >> 카페 페이지 전체 조회 기능 구현

### DIFF
--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminCafeController.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminCafeController.java
@@ -5,10 +5,9 @@ import com.sparta.coffeedeliveryproject.dto.CafeResponseDto;
 import com.sparta.coffeedeliveryproject.service.AdminCafeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/admin")
@@ -26,6 +25,14 @@ public class AdminCafeController {
         CafeResponseDto responseDto = adminCafeService.createCafe(requestDto);
 
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+
+    @GetMapping("/cafes")
+    public ResponseEntity<List<CafeResponseDto>> getAllCafe(@RequestParam(value = "page", defaultValue = "1") int page) {
+
+        List<CafeResponseDto> responseDtoList = adminCafeService.getAllCafe(page - 1);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDtoList);
     }
 
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/CafeMenusResponseDto.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/CafeMenusResponseDto.java
@@ -1,0 +1,33 @@
+package com.sparta.coffeedeliveryproject.dto;
+
+import com.sparta.coffeedeliveryproject.entity.Cafe;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class CafeMenusResponseDto {
+
+    private Long cafeId;
+
+    private String cafeName;
+
+    private String cafeInfo;
+
+    private String cafeAddress;
+
+    private Long cafeLikeCount;
+
+    private List<MenuResponseDto> menus;
+
+    public CafeMenusResponseDto(Cafe cafe, List<MenuResponseDto> menus) {
+        this.cafeId = cafe.getCafeId();
+        this.cafeName = cafe.getCafeName();
+        this.cafeInfo = cafe.getCafeInfo();
+        this.cafeAddress = cafe.getCafeAddress();
+        this.cafeLikeCount = cafe.getCafeLikeCount();
+        this.menus = menus;
+    }
+
+}

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/Cafe.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/Cafe.java
@@ -4,6 +4,9 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @Entity
@@ -26,11 +29,18 @@ public class Cafe {
     @Column(name = "cafe_like_count")
     private Long cafeLikeCount;
 
+    @OneToMany
+    private List<Menu> menus = new ArrayList<>();
+
     public Cafe(String cafeName, String cafeInfo, String cafeAddress) {
         this.cafeName = cafeName;
         this.cafeInfo = cafeInfo;
         this.cafeAddress = cafeAddress;
         this.cafeLikeCount = 0L;
+    }
+
+    public void addMenus(Menu menu) {
+        this.menus.add(menu);
     }
 
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/Cafe.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/Cafe.java
@@ -30,7 +30,7 @@ public class Cafe {
     private Long cafeLikeCount;
 
     @OneToMany
-    private List<Menu> menus = new ArrayList<>();
+    private List<Menu> menuList = new ArrayList<>();
 
     public Cafe(String cafeName, String cafeInfo, String cafeAddress) {
         this.cafeName = cafeName;
@@ -39,8 +39,8 @@ public class Cafe {
         this.cafeLikeCount = 0L;
     }
 
-    public void addMenus(Menu menu) {
-        this.menus.add(menu);
+    public void addMenuList(Menu menu) {
+        this.menuList.add(menu);
     }
 
     public void likeCafe() {

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/Cafe.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/Cafe.java
@@ -43,4 +43,12 @@ public class Cafe {
         this.menus.add(menu);
     }
 
+    public void likeCafe() {
+        this.cafeLikeCount ++;
+    }
+
+    public void unlikeCafe() {
+        this.cafeLikeCount --;
+    }
+
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminCafeService.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminCafeService.java
@@ -4,7 +4,13 @@ import com.sparta.coffeedeliveryproject.dto.CafeRequestDto;
 import com.sparta.coffeedeliveryproject.dto.CafeResponseDto;
 import com.sparta.coffeedeliveryproject.entity.Cafe;
 import com.sparta.coffeedeliveryproject.repository.CafeRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class AdminCafeService {
@@ -25,6 +31,20 @@ public class AdminCafeService {
         Cafe SaveCafe = cafeRepository.save(cafe);
 
         return new CafeResponseDto(SaveCafe);
+    }
+
+    public List<CafeResponseDto> getAllCafe(int page) {
+
+        Sort sort = Sort.by(Sort.Direction.ASC, "cafeId");
+        Pageable pageable = PageRequest.of(page, 5, sort);
+        Page<CafeResponseDto> CafePage = cafeRepository.findAll(pageable).map(CafeResponseDto::new);
+        List<CafeResponseDto> responseDtoList = CafePage.getContent();
+
+        if (responseDtoList.isEmpty()) {
+            throw new IllegalArgumentException("작성된 카페 페이지가 없거나, 입력된 " + (page + 1) + " 페이지에 글이 없습니다.");
+        }
+
+        return responseDtoList;
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#30 

## 📝 작업 내용

- Cafe Entity에 Menu Entity와 연관 관계 맵핑
- MenuList를 가지는 CafeMenusResponseDto 생성 및 구현
- Cafe Entity에 카페 좋아요를 위한 메서드 추가
- AdminCafeController에 getAllCafe API 구현
- AdminCafeService에 getAllCafe 메서드 로직 구현
- 페이징 기능 추가 구현

### 📸 스크린샷 (선택)

- 1 페이지 요청(페이지 당 갯수 / Size = 5)
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/48900537/7757e13b-afbf-4a4b-9e8a-617d152a546c)

- DB 확인용
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/48900537/767c7f9f-dc1f-4ce4-97d2-19ce3e340543)

## 💬 리뷰 요구사항(선택)

현재는 cafeId를 기준으로 오름차순으로, 한 페이지 당 갯수는 5개로 설정해놨습니다. 혹시 설정을 바꾸시고 싶으면 말씀해주세요!
