### PR TITLE
[2024/06/22] feat/edit-profile >> 유저 본인 프로필 수정 기능

### DIFF
--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminUserController.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminUserController.java
@@ -69,7 +69,6 @@ public class AdminUserController {
     @ExceptionHandler
     private ResponseEntity<String> handleException(IllegalArgumentException e) {
         return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
-
     }
 
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/UserController.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/UserController.java
@@ -1,13 +1,15 @@
 package com.sparta.coffeedeliveryproject.controller;
 
 import com.sparta.coffeedeliveryproject.dto.SignupRequestDto;
+import com.sparta.coffeedeliveryproject.dto.UserProfileEditRequestDto;
+import com.sparta.coffeedeliveryproject.dto.UserProfileEditResponseDto;
+import com.sparta.coffeedeliveryproject.security.UserDetailsImpl;
 import com.sparta.coffeedeliveryproject.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +23,16 @@ public class UserController {
 
         userService.signup(signupRequestDto);
         return ResponseEntity.ok("회원가입 성공");
+    }
+
+    @PutMapping("/profile")
+    public UserProfileEditResponseDto editProfile(@RequestBody UserProfileEditRequestDto userProfileEditRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return userService.editProfile(userProfileEditRequestDto, userDetails.getUser().getUserId());
+    }
+
+    @ExceptionHandler
+    private ResponseEntity<String> handleException(IllegalArgumentException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/UserProfileEditRequestDto.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/UserProfileEditRequestDto.java
@@ -1,0 +1,14 @@
+package com.sparta.coffeedeliveryproject.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserProfileEditRequestDto {
+
+    private String newNickName;
+
+    private String password;
+
+    private String newPassword;
+
+}

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/UserProfileEditResponseDto.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/UserProfileEditResponseDto.java
@@ -1,0 +1,20 @@
+package com.sparta.coffeedeliveryproject.dto;
+
+import com.sparta.coffeedeliveryproject.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserProfileEditResponseDto {
+
+    private String nickName;
+
+    private String password;
+
+    public UserProfileEditResponseDto(User user) {
+        this.nickName = user.getNickName();
+        this.password = user.getPassword();
+    }
+
+}

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/UserService.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/UserService.java
@@ -1,7 +1,11 @@
 package com.sparta.coffeedeliveryproject.service;
 
 import com.sparta.coffeedeliveryproject.dto.SignupRequestDto;
+import com.sparta.coffeedeliveryproject.dto.UserProfileEditRequestDto;
+import com.sparta.coffeedeliveryproject.dto.UserProfileEditResponseDto;
 import com.sparta.coffeedeliveryproject.entity.User;
+import com.sparta.coffeedeliveryproject.exceptions.PasswordMismatchException;
+import com.sparta.coffeedeliveryproject.exceptions.RecentlyUsedPasswordException;
 import com.sparta.coffeedeliveryproject.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,6 +38,52 @@ public class UserService {
         userRepository.save(user);
 
         return "회원가입 성공";
+    }
+
+    public UserProfileEditResponseDto editProfile(UserProfileEditRequestDto userProfileEditRequestDto, Long userId) {
+        User user = findUserById(userId);
+
+        if (userProfileEditRequestDto.getNewNickName() != null) {
+            user.editUserNickName(userProfileEditRequestDto.getNewNickName());
+        }
+
+        // 현재 비밀번호 확인
+        if (userProfileEditRequestDto.getPassword() != null) {
+            // TODO: 나중에 password 암호화되면 encoder 추가 필요
+            // 일치하지 않으면
+            if (!userProfileEditRequestDto.getPassword().matches(user.getPassword())) {
+                throw new PasswordMismatchException("현재 비밀번호가 일치하지 않습니다.");
+            }
+
+            // 이전 비밀번호에 새로운 비밀번호가 있으면
+            if (user.getPastPasswords().contains(userProfileEditRequestDto.getNewPassword())) {
+                throw new RecentlyUsedPasswordException("최근 설정한 4개의 비밀번호로는 비밀번호를 변경하실 수 없습니다.");
+            }
+
+            // 새로운 비밀번호 설정
+            user.editUserPassword(userProfileEditRequestDto.getNewPassword());
+
+            // 과거 비밀번호 저장하는 리스트의 갯수가 4개인지 확인
+            if (user.getPastPasswords().stream().count() == 4) {
+
+                // 가장 먼저 저장된 password 삭제
+                user.getPastPasswords().remove(0);
+
+                // 새로운 비밀번호 저장
+                user.getPastPasswords().add(userProfileEditRequestDto.getNewPassword());
+
+            } else {
+                user.getPastPasswords().add(userProfileEditRequestDto.getNewPassword());
+            }
+        }
+
+        return new UserProfileEditResponseDto(user);
+
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자의 프로필을 찾을 수 없습니다."));
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#44 
close #44

## 📝 작업 내용
- 유저 본인이 본인 프로필을 수정할 수 있는 기능을 구현
- 본인의 닉네임, 비밀번호 수정 가능
- 비밀번호 검증 후 틀리면 변경 불가, 최근 4번의 비밀번호면 변경 불가 (예외처리)

## 💬 리뷰 요구사항
로그인 기능이 아직 되질 않아 실제 동작 테스트는 못 했습니다. 혹시라도 나중에 오류가 있으면 수정하겠습니다!