### PR TITLE
[2024/06/22] feat/delete-cafe >> 카페 페이지 삭제 기능 구현

### DIFF
--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminCafeController.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminCafeController.java
@@ -3,6 +3,7 @@ package com.sparta.coffeedeliveryproject.controller;
 import com.sparta.coffeedeliveryproject.dto.CafeEditRequestDto;
 import com.sparta.coffeedeliveryproject.dto.CafeRequestDto;
 import com.sparta.coffeedeliveryproject.dto.CafeResponseDto;
+import com.sparta.coffeedeliveryproject.dto.MessageResponseDto;
 import com.sparta.coffeedeliveryproject.service.AdminCafeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -41,6 +42,14 @@ public class AdminCafeController {
                                                     @RequestBody CafeEditRequestDto requestDto) {
 
         CafeResponseDto responseDto = adminCafeService.editCafe(cafeId, requestDto);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+
+    @DeleteMapping("/cafes/{cafeId}")
+    public ResponseEntity<MessageResponseDto> deleteCafe(@PathVariable(value = "cafeId") Long cafeId) {
+
+        MessageResponseDto responseDto = adminCafeService.deleteCafe(cafeId);
 
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminCafeService.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminCafeService.java
@@ -81,4 +81,5 @@ public class AdminCafeService {
                 () -> new IllegalArgumentException("해당 카페 페이지를 찾을 수 없습니다.")
         );
     }
+
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminCafeService.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminCafeService.java
@@ -3,6 +3,7 @@ package com.sparta.coffeedeliveryproject.service;
 import com.sparta.coffeedeliveryproject.dto.CafeEditRequestDto;
 import com.sparta.coffeedeliveryproject.dto.CafeRequestDto;
 import com.sparta.coffeedeliveryproject.dto.CafeResponseDto;
+import com.sparta.coffeedeliveryproject.dto.MessageResponseDto;
 import com.sparta.coffeedeliveryproject.entity.Cafe;
 import com.sparta.coffeedeliveryproject.repository.CafeRepository;
 import org.springframework.data.domain.Page;
@@ -65,11 +66,19 @@ public class AdminCafeService {
         return new CafeResponseDto(cafe);
     }
 
+    public MessageResponseDto deleteCafe(Long cafeId) {
+
+        Cafe cafe = findCafeById(cafeId);
+
+        cafeRepository.delete(cafe);
+
+        return new MessageResponseDto("삭제 완료 되었습니다.");
+    }
+
     private Cafe findCafeById(Long cafeId){
 
         return cafeRepository.findById(cafeId).orElseThrow(
                 () -> new IllegalArgumentException("해당 카페 페이지를 찾을 수 없습니다.")
         );
     }
-
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#43 

## 📝 작업 내용

- AdminCafeController에 deleteCafe API 구현
- AdminCafeService에 deleteCafe 메서드 로직 구현

### 📸 스크린샷 (선택)

- cafeId 8번 삭제 요청
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/48900537/be8c2cd3-c639-4363-87cd-9d33240ff9c8)
