### PR TITLE
[2024/06/22] feat/get-cafe-user >> 일반 유저 카페 페이지 단건 조회 기능 구현

### DIFF
--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminMenuController.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminMenuController.java
@@ -3,26 +3,26 @@ package com.sparta.coffeedeliveryproject.controller;
 import com.sparta.coffeedeliveryproject.dto.MenuRequestDto;
 import com.sparta.coffeedeliveryproject.dto.MenuResponseDto;
 import com.sparta.coffeedeliveryproject.dto.MessageResponseDto;
-import com.sparta.coffeedeliveryproject.service.MenuService;
+import com.sparta.coffeedeliveryproject.service.AdminMenuService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/admin/cafes")
-public class MenuController {
+public class AdminMenuController {
 
-    private final MenuService menuService;
+    private final AdminMenuService adminMenuService;
 
-    public  MenuController(MenuService menuService) {
-        this.menuService = menuService;
+    public AdminMenuController(AdminMenuService adminMenuService) {
+        this.adminMenuService = adminMenuService;
     }
 
     @PostMapping("/{cafeId}/menus")
     public ResponseEntity<MenuResponseDto> createMenu(@PathVariable(value = "cafeId") Long cafeId,
                                                       @RequestBody MenuRequestDto requestDto) {
 
-        MenuResponseDto responseDto = menuService.createMenu(cafeId, requestDto);
+        MenuResponseDto responseDto = adminMenuService.createMenu(cafeId, requestDto);
 
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
@@ -30,7 +30,7 @@ public class MenuController {
     @DeleteMapping("/menus/{menuId}")
     public ResponseEntity<MessageResponseDto> deleteMenu(@PathVariable(value = "menuId") Long menuId) {
 
-       MessageResponseDto responseDto = menuService.deleteMenu(menuId);
+       MessageResponseDto responseDto = adminMenuService.deleteMenu(menuId);
 
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/CafeController.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/CafeController.java
@@ -1,13 +1,11 @@
 package com.sparta.coffeedeliveryproject.controller;
 
+import com.sparta.coffeedeliveryproject.dto.CafeMenuListResponseDto;
 import com.sparta.coffeedeliveryproject.dto.CafeResponseDto;
 import com.sparta.coffeedeliveryproject.service.CafeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -28,6 +26,14 @@ public class CafeController {
         List<CafeResponseDto> responseDtoList = cafeService.getAllCafe(page - 1, sortBy);
 
         return ResponseEntity.status(HttpStatus.OK).body(responseDtoList);
+    }
+
+    @GetMapping("/{cafeId}")
+    public ResponseEntity<CafeMenuListResponseDto> getCafeWithMenuList(@PathVariable(value = "cafeId") Long cafeId) {
+
+        CafeMenuListResponseDto responseDto = cafeService.getCafeWithMenuList(cafeId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/CafeMenuListResponseDto.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/dto/CafeMenuListResponseDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import java.util.List;
 
 @Getter
-public class CafeMenusResponseDto {
+public class CafeMenuListResponseDto {
 
     private Long cafeId;
 
@@ -18,15 +18,15 @@ public class CafeMenusResponseDto {
 
     private Long cafeLikeCount;
 
-    private List<MenuResponseDto> menus;
+    private List<MenuResponseDto> menuList;
 
-    public CafeMenusResponseDto(Cafe cafe, List<MenuResponseDto> menus) {
+    public CafeMenuListResponseDto(Cafe cafe, List<MenuResponseDto> menuList) {
         this.cafeId = cafe.getCafeId();
         this.cafeName = cafe.getCafeName();
         this.cafeInfo = cafe.getCafeInfo();
         this.cafeAddress = cafe.getCafeAddress();
         this.cafeLikeCount = cafe.getCafeLikeCount();
-        this.menus = menus;
+        this.menuList = menuList;
     }
 
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/Cafe.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/entity/Cafe.java
@@ -29,7 +29,7 @@ public class Cafe {
     @Column(name = "cafe_like_count")
     private Long cafeLikeCount;
 
-    @OneToMany
+    @OneToMany(mappedBy = "cafe", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<Menu> menuList = new ArrayList<>();
 
     public Cafe(String cafeName, String cafeInfo, String cafeAddress) {

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminMenuService.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminMenuService.java
@@ -29,6 +29,7 @@ public class AdminMenuService {
         String menuName = requestDto.getMenuName();
         Long menuPrice = requestDto.getMenuPrice();
         Menu menu = new Menu(menuName, menuPrice, cafe);
+        cafe.addMenuList(menu);
 
         Menu saveMenu = menuRepository.save(menu);
 

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminMenuService.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminMenuService.java
@@ -10,12 +10,12 @@ import com.sparta.coffeedeliveryproject.repository.MenuRepository;
 import org.springframework.stereotype.Service;
 
 @Service
-public class MenuService {
+public class AdminMenuService {
 
     private final MenuRepository menuRepository;
     private final CafeRepository cafeRepository;
 
-    public MenuService(MenuRepository menuRepository, CafeRepository cafeRepository) {
+    public AdminMenuService(MenuRepository menuRepository, CafeRepository cafeRepository) {
         this.menuRepository = menuRepository;
         this.cafeRepository = cafeRepository;
     }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/CafeService.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/CafeService.java
@@ -1,6 +1,9 @@
 package com.sparta.coffeedeliveryproject.service;
 
+import com.sparta.coffeedeliveryproject.dto.CafeMenuListResponseDto;
 import com.sparta.coffeedeliveryproject.dto.CafeResponseDto;
+import com.sparta.coffeedeliveryproject.dto.MenuResponseDto;
+import com.sparta.coffeedeliveryproject.entity.Cafe;
 import com.sparta.coffeedeliveryproject.repository.CafeRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -38,6 +41,17 @@ public class CafeService {
         }
 
         return responseDtoList;
+    }
+
+    public CafeMenuListResponseDto getCafeWithMenuList(Long cafeId) {
+
+        Cafe cafe = cafeRepository.findById(cafeId).orElseThrow(
+                () -> new IllegalArgumentException("해당 카페 페이지를 찾을 수 없습니다.")
+        );
+
+        List<MenuResponseDto> menuList = cafe.getMenuList().stream().map(MenuResponseDto::new).toList();
+
+        return new CafeMenuListResponseDto(cafe, menuList);
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#52 

## 📝 작업 내용

- Cafe와 Menu 간의 연관관계 맵핑 오류로 인한 수정
- CafeContoller에 getCafeWithMenuList API 구현
- CafeService에 getCafeWithMenuList 메서드 로직 구현

### 📸 스크린샷 (선택)

- cafeId 2번인 Cafe 조회 결과 (해당 카페에 맵핑된 메뉴 리스트 포함)
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/48900537/7eb0f7cb-bdce-4125-acbe-17942bfb671b)
