### PR TITLE
[2024/06/24] feat/authorization-order >> 주문상태 관련 API 어드민만 가능하도록 변경

### DIFF
--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminOrderController.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminOrderController.java
@@ -1,10 +1,12 @@
 package com.sparta.coffeedeliveryproject.controller;
 
 import com.sparta.coffeedeliveryproject.dto.MessageResponseDto;
+import com.sparta.coffeedeliveryproject.security.UserDetailsImpl;
 import com.sparta.coffeedeliveryproject.service.AdminOrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,23 +18,38 @@ public class AdminOrderController {
 
     // 주문 상태 변경(완료)
     @PutMapping("/orders/{orderId}")
-    public ResponseEntity<MessageResponseDto> completeOrder(@PathVariable Long orderId) {
-        MessageResponseDto responseDto = adminOrderService.completeOrder(orderId);
-        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    public ResponseEntity<MessageResponseDto> completeOrder(@PathVariable Long orderId,
+                                                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (adminOrderService.isAdmin(userDetails)) {
+            MessageResponseDto responseDto = adminOrderService.completeOrder(orderId);
+            return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        } else {
+            return ResponseEntity.status(403).body(new MessageResponseDto("어드민만 가능한 기능입니다."));
+        }
     }
 
     // 주문 상태 변경(취소)
     @PutMapping("/orders/cancel/{orderId}")
-    public ResponseEntity<MessageResponseDto> cancelOrder(@PathVariable Long orderId) {
-        MessageResponseDto responseDto = adminOrderService.cancelOrder(orderId);
-        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    public ResponseEntity<MessageResponseDto> cancelOrder(@PathVariable Long orderId,
+                                                          @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (adminOrderService.isAdmin(userDetails)) {
+            MessageResponseDto responseDto = adminOrderService.cancelOrder(orderId);
+            return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        } else {
+            return ResponseEntity.status(403).body(new MessageResponseDto("어드민만 가능한 기능입니다."));
+        }
     }
 
     // 주문 삭제
     @DeleteMapping("/orders/{orderId}")
-    public ResponseEntity<MessageResponseDto> deleteOrder(@PathVariable Long orderId) {
-        MessageResponseDto responseDto = adminOrderService.deleteOrder(orderId);
-        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    public ResponseEntity<MessageResponseDto> deleteOrder(@PathVariable Long orderId,
+                                                          @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (adminOrderService.isAdmin(userDetails)) {
+            MessageResponseDto responseDto = adminOrderService.deleteOrder(orderId);
+            return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        } else {
+            return ResponseEntity.status(403).body(new MessageResponseDto("어드민만 가능한 기능입니다."));
+        }
     }
 
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminOrderService.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminOrderService.java
@@ -3,7 +3,11 @@ package com.sparta.coffeedeliveryproject.service;
 import com.sparta.coffeedeliveryproject.dto.MessageResponseDto;
 import com.sparta.coffeedeliveryproject.entity.Order;
 import com.sparta.coffeedeliveryproject.entity.OrderStatus;
+import com.sparta.coffeedeliveryproject.entity.User;
+import com.sparta.coffeedeliveryproject.entity.UserRole;
 import com.sparta.coffeedeliveryproject.repository.OrderRepository;
+import com.sparta.coffeedeliveryproject.repository.UserRepository;
+import com.sparta.coffeedeliveryproject.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminOrderService {
 
     private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
 
     //주문 상태 변경(완료)
     @Transactional
@@ -41,6 +46,20 @@ public class AdminOrderService {
     private Order findOrderById(Long orderId) {
         return orderRepository.findById(orderId).orElseThrow(() ->
                 new IllegalArgumentException("해당 주문을 찾을 수 없습니다."));
+    }
+
+    // 어드민인지 구분
+    @Transactional
+    public boolean isAdmin(UserDetailsImpl userDetails) {
+        User user = userRepository.findById(userDetails.getUser().getUserId()).orElseThrow(
+                () -> new IllegalArgumentException("해당 사용자가 없습니다."));
+
+        for (UserRole role : user.getUserRoles()) {
+            if ("ADMIN".equals(role.getRole())) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#15 

## 📝 작업 내용
주문 상태 변경(완료, 취소) 메서드 , 주문 삭제 메서드 어드민만 가능하도록 변경


### 📸 스크린샷 
- 주문 상태 변경 (완료)
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/166794538/0c28018b-2d14-4fce-9c0e-52d1a01b822f)

![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/166794538/9b8bc8ae-df9e-4604-ac49-1e4e2cc13082)

- 주문 상태 변경 (취소)
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/166794538/75f16a97-a854-44e5-99c2-08be1a0720f7)

![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/166794538/5c5c7a76-2977-424a-99c1-27646cb0543b)

- 주문 삭제
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/166794538/6f85b576-62d1-402f-aa06-6369d36889bc)

- 어드민이 아닌 유저가 요청시
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/166794538/42fd4679-19a7-405d-85be-3e867c693e91)

