### PR TITLE
[2024/06/24] refactor/admin-cafe >> Cafe, Menu API Admin 확인 기능 구현

### DIFF
--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/config/WebSecurityConfig.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/config/WebSecurityConfig.java
@@ -7,13 +7,12 @@ import com.sparta.coffeedeliveryproject.security.UserDetailsServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -48,8 +47,10 @@ public class WebSecurityConfig {
         http.authorizeHttpRequests((authorizeHttpRequests) ->
                 authorizeHttpRequests
                         .requestMatchers("/").permitAll()
-                        .requestMatchers("/users/signup").permitAll()
-                        .requestMatchers("/users/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/users/signup").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/users/login").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/cafes").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/cafes/{cafeId}").permitAll()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );
 

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminCafeController.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminCafeController.java
@@ -4,55 +4,71 @@ import com.sparta.coffeedeliveryproject.dto.CafeEditRequestDto;
 import com.sparta.coffeedeliveryproject.dto.CafeRequestDto;
 import com.sparta.coffeedeliveryproject.dto.CafeResponseDto;
 import com.sparta.coffeedeliveryproject.dto.MessageResponseDto;
+import com.sparta.coffeedeliveryproject.security.UserDetailsImpl;
 import com.sparta.coffeedeliveryproject.service.AdminCafeService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/admin")
+@RequiredArgsConstructor
 public class AdminCafeController {
 
     private final AdminCafeService adminCafeService;
 
-    public AdminCafeController(AdminCafeService adminCafeService) {
-        this.adminCafeService = adminCafeService;
-    }
-
     @PostMapping("/cafes")
-    public ResponseEntity<CafeResponseDto> createCafe(@Valid @RequestBody CafeRequestDto requestDto) {
+    public ResponseEntity<CafeResponseDto> createCafe(@Valid @RequestBody CafeRequestDto requestDto,
+                                                      @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        CafeResponseDto responseDto = adminCafeService.createCafe(requestDto);
-
-        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        if (adminCafeService.isAdmin(userDetails)) {
+            CafeResponseDto responseDto = adminCafeService.createCafe(requestDto);
+            return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        } else {
+            throw new IllegalArgumentException("관리자만 사용할 수 있는 기능입니다.");
+        }
     }
 
     @GetMapping("/cafes")
-    public ResponseEntity<List<CafeResponseDto>> getAllCafe(@RequestParam(value = "page", defaultValue = "1") int page) {
+    public ResponseEntity<List<CafeResponseDto>> getAllCafe(@RequestParam(value = "page", defaultValue = "1") int page,
+                                                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        List<CafeResponseDto> responseDtoList = adminCafeService.getAllCafe(page - 1);
-
-        return ResponseEntity.status(HttpStatus.OK).body(responseDtoList);
+        if (adminCafeService.isAdmin(userDetails)) {
+            List<CafeResponseDto> responseDtoList = adminCafeService.getAllCafe(page - 1);
+            return ResponseEntity.status(HttpStatus.OK).body(responseDtoList);
+        } else {
+            throw new IllegalArgumentException("관리자만 사용할 수 있는 기능입니다.");
+        }
     }
 
     @PutMapping("/cafes/{cafeId}")
     public ResponseEntity<CafeResponseDto> editCafe(@PathVariable(value = "cafeId") Long cafeId,
-                                                    @RequestBody CafeEditRequestDto requestDto) {
+                                                    @RequestBody CafeEditRequestDto requestDto,
+                                                    @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        CafeResponseDto responseDto = adminCafeService.editCafe(cafeId, requestDto);
-
-        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        if (adminCafeService.isAdmin(userDetails)) {
+            CafeResponseDto responseDto = adminCafeService.editCafe(cafeId, requestDto);
+            return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        } else {
+            throw new IllegalArgumentException("관리자만 사용할 수 있는 기능입니다.");
+        }
     }
 
     @DeleteMapping("/cafes/{cafeId}")
-    public ResponseEntity<MessageResponseDto> deleteCafe(@PathVariable(value = "cafeId") Long cafeId) {
+    public ResponseEntity<MessageResponseDto> deleteCafe(@PathVariable(value = "cafeId") Long cafeId,
+                                                         @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        MessageResponseDto responseDto = adminCafeService.deleteCafe(cafeId);
-
-        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        if (adminCafeService.isAdmin(userDetails)) {
+            MessageResponseDto responseDto = adminCafeService.deleteCafe(cafeId);
+            return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        } else {
+            throw new IllegalArgumentException("관리자만 사용할 수 있는 기능입니다.");
+        }
     }
 
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminMenuController.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/AdminMenuController.java
@@ -3,37 +3,45 @@ package com.sparta.coffeedeliveryproject.controller;
 import com.sparta.coffeedeliveryproject.dto.MenuRequestDto;
 import com.sparta.coffeedeliveryproject.dto.MenuResponseDto;
 import com.sparta.coffeedeliveryproject.dto.MessageResponseDto;
+import com.sparta.coffeedeliveryproject.security.UserDetailsImpl;
 import com.sparta.coffeedeliveryproject.service.AdminMenuService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/admin/cafes")
+@RequiredArgsConstructor
 public class AdminMenuController {
 
     private final AdminMenuService adminMenuService;
 
-    public AdminMenuController(AdminMenuService adminMenuService) {
-        this.adminMenuService = adminMenuService;
-    }
-
     @PostMapping("/{cafeId}/menus")
     public ResponseEntity<MenuResponseDto> createMenu(@PathVariable(value = "cafeId") Long cafeId,
-                                                      @Valid @RequestBody MenuRequestDto requestDto) {
+                                                      @Valid @RequestBody MenuRequestDto requestDto,
+                                                      @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        MenuResponseDto responseDto = adminMenuService.createMenu(cafeId, requestDto);
-
-        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        if (adminMenuService.isAdmin(userDetails)) {
+            MenuResponseDto responseDto = adminMenuService.createMenu(cafeId, requestDto);
+            return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        } else {
+            throw new IllegalArgumentException("관리자만 사용할 수 있는 기능입니다.");
+        }
     }
 
     @DeleteMapping("/menus/{menuId}")
-    public ResponseEntity<MessageResponseDto> deleteMenu(@PathVariable(value = "menuId") Long menuId) {
+    public ResponseEntity<MessageResponseDto> deleteMenu(@PathVariable(value = "menuId") Long menuId,
+                                                         @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-       MessageResponseDto responseDto = adminMenuService.deleteMenu(menuId);
-
-        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        if (adminMenuService.isAdmin(userDetails)) {
+            MessageResponseDto responseDto = adminMenuService.deleteMenu(menuId);
+            return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        } else {
+            throw new IllegalArgumentException("관리자만 사용할 수 있는 기능입니다.");
+        }
     }
 
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/CafeController.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/controller/CafeController.java
@@ -3,6 +3,7 @@ package com.sparta.coffeedeliveryproject.controller;
 import com.sparta.coffeedeliveryproject.dto.CafeMenuListResponseDto;
 import com.sparta.coffeedeliveryproject.dto.CafeResponseDto;
 import com.sparta.coffeedeliveryproject.service.CafeService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,13 +12,10 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/cafes")
+@RequiredArgsConstructor
 public class CafeController {
 
     private final CafeService cafeService;
-
-    public CafeController(CafeService cafeService) {
-        this.cafeService = cafeService;
-    }
 
     @GetMapping
     public ResponseEntity<List<CafeResponseDto>> getAllCafe(@RequestParam(value = "page", defaultValue = "1") int page,

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminCafeService.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminCafeService.java
@@ -5,7 +5,12 @@ import com.sparta.coffeedeliveryproject.dto.CafeRequestDto;
 import com.sparta.coffeedeliveryproject.dto.CafeResponseDto;
 import com.sparta.coffeedeliveryproject.dto.MessageResponseDto;
 import com.sparta.coffeedeliveryproject.entity.Cafe;
+import com.sparta.coffeedeliveryproject.entity.User;
+import com.sparta.coffeedeliveryproject.entity.UserRole;
 import com.sparta.coffeedeliveryproject.repository.CafeRepository;
+import com.sparta.coffeedeliveryproject.repository.UserRepository;
+import com.sparta.coffeedeliveryproject.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -16,13 +21,11 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class AdminCafeService {
 
     private final CafeRepository cafeRepository;
-
-    public AdminCafeService(CafeRepository cafeRepository) {
-        this.cafeRepository = cafeRepository;
-    }
+    private final UserRepository userRepository;
 
     public CafeResponseDto createCafe(CafeRequestDto requestDto) {
 
@@ -95,6 +98,19 @@ public class AdminCafeService {
     // String 요청 데이터가 비어 있느지 확인하는 메서드
     private boolean isNullAndEmpty(String string) {
         return string == null || string.isEmpty();
+    }
+
+    @Transactional
+    public boolean isAdmin(UserDetailsImpl userDetails) {
+        User user = userRepository.findById(userDetails.getUser().getUserId()).orElseThrow(
+                () -> new IllegalArgumentException("해당 사용자가 없습니다."));
+
+        for (UserRole role : user.getUserRoles()) {
+            if ("ADMIN".equals(role.getRole())) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminMenuService.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/AdminMenuService.java
@@ -5,20 +5,23 @@ import com.sparta.coffeedeliveryproject.dto.MenuResponseDto;
 import com.sparta.coffeedeliveryproject.dto.MessageResponseDto;
 import com.sparta.coffeedeliveryproject.entity.Cafe;
 import com.sparta.coffeedeliveryproject.entity.Menu;
+import com.sparta.coffeedeliveryproject.entity.User;
+import com.sparta.coffeedeliveryproject.entity.UserRole;
 import com.sparta.coffeedeliveryproject.repository.CafeRepository;
 import com.sparta.coffeedeliveryproject.repository.MenuRepository;
+import com.sparta.coffeedeliveryproject.repository.UserRepository;
+import com.sparta.coffeedeliveryproject.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class AdminMenuService {
 
     private final MenuRepository menuRepository;
     private final CafeRepository cafeRepository;
-
-    public AdminMenuService(MenuRepository menuRepository, CafeRepository cafeRepository) {
-        this.menuRepository = menuRepository;
-        this.cafeRepository = cafeRepository;
-    }
+    private final UserRepository userRepository;
 
     public MenuResponseDto createMenu(Long cafeId, MenuRequestDto requestDto) {
 
@@ -45,6 +48,19 @@ public class AdminMenuService {
         menuRepository.delete(menu);
 
         return new MessageResponseDto("삭제 완료 되었습니다.");
+    }
+
+    @Transactional
+    public boolean isAdmin(UserDetailsImpl userDetails) {
+        User user = userRepository.findById(userDetails.getUser().getUserId()).orElseThrow(
+                () -> new IllegalArgumentException("해당 사용자가 없습니다."));
+
+        for (UserRole role : user.getUserRoles()) {
+            if ("ADMIN".equals(role.getRole())) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/CafeService.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/CafeService.java
@@ -5,6 +5,7 @@ import com.sparta.coffeedeliveryproject.dto.CafeResponseDto;
 import com.sparta.coffeedeliveryproject.dto.MenuResponseDto;
 import com.sparta.coffeedeliveryproject.entity.Cafe;
 import com.sparta.coffeedeliveryproject.repository.CafeRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -14,13 +15,10 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class CafeService {
 
     private final CafeRepository cafeRepository;
-
-    public CafeService(CafeRepository cafeRepository) {
-        this.cafeRepository = cafeRepository;
-    }
 
     public List<CafeResponseDto> getAllCafe(int page, String sortBy) {
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#74 

## 📝 작업 내용

- WebSecurityConfig에 인가 통과 API에 Cafe get API 두개 추가
- Cafe API Admin 만 수행 가능한 API에 대해 확인하는 로직 추가
- Menu API Admin 만 수행 가능한 API에 대해 확인하는 로직 추가
- Cafe, Menu Controller, Service 생성자 @requiredargsconstructor로 수정
