### PR TITLE
[2024/06/24] feat/get-order >> 주문 목록이 비어있을 때 오류 처리

### DIFF
--- a/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/OrderService.java
+++ b/CoffeeDeliveryProject/src/main/java/com/sparta/coffeedeliveryproject/service/OrderService.java
@@ -49,8 +49,12 @@ public class OrderService {
             );
             orderResponseDtos.add(orderResponseDto);
         }
+        if (!orders.isEmpty()) {
+            return orderResponseDtos;
+        } else {
+            throw new IllegalArgumentException("주문 목록이 비어있습니다.");
+        }
 
-        return orderResponseDtos;
     }
 
     //id로 메뉴 찾기


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#7 

## 📝 작업 내용

 주문 목록이 비어있을 때 오류 처리 추가

### 📸 스크린샷 (선택)
![image](https://github.com/LeeChangHyeong/CoffeeDeliveryProject/assets/166794538/8804d314-f77e-483a-a7c0-a06146e2c37e)


